### PR TITLE
Feat: Build and upload all package variants

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -10,9 +10,11 @@ jobs:
   build:
     runs-on:
       labels: oc-runner
+
     permissions:
       id-token: "write"
       contents: "write"
+
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -21,8 +23,8 @@ jobs:
           name: nixos-asahi
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - name: Build package
-        run: nix build -L .#installerPackage
+      - name: Build metapackage
+        run: nix-fast-build --eval-workers 24 --no-nom --skip-cached
 
       - name: Release
         uses: softprops/action-gh-release@v2.2.1
@@ -44,4 +46,4 @@ jobs:
           export SECRET_ACCESS_KEY=${{ secrets.SECRET_ACCESS_KEY }}
           EOF
 
-          nix run .#upload
+          nix run .#upload -- ./result-aarch64-linux

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -24,7 +24,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: Build metapackage
-        run: nix-fast-build --eval-workers 24 --no-nom --skip-cached
+        run: nix run "github:mic92/nix-fast-build" -- --eval-workers 24 --no-nom --skip-cached
 
       - name: Release
         uses: softprops/action-gh-release@v2.2.1
@@ -41,6 +41,7 @@ jobs:
           touch ./.env
           cat > .env <<EOF
           export ACCESS_KEY_ID=${{ secrets.ACCESS_KEY_ID }}
+          export BASE_URL="https://cdn.qeden.dev"
           export BUCKET_NAME=${{ secrets.BUCKET_NAME }}
           export ENDPOINT_URL=${{ secrets.ENDPOINT_URL }}
           export SECRET_ACCESS_KEY=${{ secrets.SECRET_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
+__pycache__
 .DS_Store
 .direnv
 .env
 .env.*
-.ropeproject
 result*
 *.img
 *.zip

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
       };
     in
     {
-      packages.aarch64-linux = buildPackages.buildVariants [
+      packages.aarch64-linux = buildPackages.mkPackageVariants [
         "btrfs"
         "ext4"
       ];
@@ -76,6 +76,14 @@
           };
         }
       );
+
+      checks.aarch64-linux = nixpkgs.legacyPackages.aarch64-linux.symlinkJoin {
+        name = "nixos-asahi-metapackage";
+        paths = with self.packages.aarch64-linux.installerPackage; [
+          ext4
+          btrfs
+        ];
+      };
 
       formatter = forEachSystem ({ pkgs }: pkgs.nixfmt-rfc-style);
     };

--- a/lib/build-packages.nix
+++ b/lib/build-packages.nix
@@ -1,0 +1,41 @@
+{
+  inputs,
+  lib,
+  nixpkgs,
+  version,
+}:
+let
+  pkgs = import nixpkgs { system = "aarch64-linux"; };
+
+  mkNixosConfig =
+    fsType:
+    lib.nixosSystem {
+      system = "aarch64-linux";
+      specialArgs = {
+        modulesPath = nixpkgs + "/nixos/modules";
+        inherit fsType inputs version;
+      };
+      modules = [ ../modules/image-config.nix ];
+    };
+
+  mkInstallerPkg = image: pkgs.callPackage ../package.nix { inherit image lib version; };
+in
+{
+  buildVariants =
+    variants:
+    builtins.listToAttrs (
+      map (variant: {
+        name = variant;
+        value =
+          let
+            inherit (mkNixosConfig variant) config;
+          in
+          rec {
+            image = config.system.build.asahi-image // {
+              passthru = { inherit config; };
+            };
+            installerPackage = mkInstallerPkg image;
+          };
+      }) variants
+    );
+}

--- a/lib/generate-installer-data.nix
+++ b/lib/generate-installer-data.nix
@@ -2,15 +2,13 @@
 {
   generateInstallerData =
     {
-      baseUrl ? "https://pub-4b458b0cfaa1441eb321ecefef7d540e.r2.dev",
-      espSize,
-      fsType,
-      rootSize,
-      version ? (import ./version.nix).version,
+      baseUrl,
+      partInfo,
+      version,
     }:
     let
       nixpkgsVersion = lib.versions.majorMinor lib.version;
-      pkgName = "nixos-asahi-" + version + "-" + fsType;
+      pkgName = "nixos-asahi-" + version + "-" + partInfo.fsType;
     in
     lib.generators.toJSON { } {
       name = "NixOS ${nixpkgsVersion} (${pkgName})";
@@ -31,7 +29,7 @@
         {
           name = "EFI";
           type = "EFI";
-          size = "${toString espSize}B";
+          size = "${toString partInfo.espSize}B";
           format = "fat";
           volume_id = "0x12cea600";
           copy_firmware = true;
@@ -41,7 +39,7 @@
         {
           name = "Root";
           type = "Linux";
-          size = "${toString rootSize}B";
+          size = "${toString partInfo.rootSize}B";
           expand = true;
           image = "root.img";
         }

--- a/lib/generate-installer-data.nix
+++ b/lib/generate-installer-data.nix
@@ -1,48 +1,46 @@
 { lib, ... }:
+
 {
-  generateInstallerData =
+  baseUrl,
+  partInfo,
+  version,
+}:
+let
+  nixpkgsVersion = lib.versions.majorMinor lib.version;
+  pkgName = "nixos-asahi-" + version + "-" + partInfo.fsType;
+in
+lib.generators.toJSON { } {
+  name = "NixOS ${nixpkgsVersion} (${pkgName})";
+  default_os_name = "NixOS";
+
+  boot_object = "m1n1.bin";
+  next_object = "m1n1/boot.bin";
+
+  package = baseUrl + "/os/" + pkgName + ".zip";
+
+  supported_fw = [
+    "12.3"
+    "12.3.1"
+    "13.5"
+  ];
+
+  partitions = [
     {
-      baseUrl,
-      partInfo,
-      version,
-    }:
-    let
-      nixpkgsVersion = lib.versions.majorMinor lib.version;
-      pkgName = "nixos-asahi-" + version + "-" + partInfo.fsType;
-    in
-    lib.generators.toJSON { } {
-      name = "NixOS ${nixpkgsVersion} (${pkgName})";
-      default_os_name = "NixOS";
-
-      boot_object = "m1n1.bin";
-      next_object = "m1n1/boot.bin";
-
-      package = baseUrl + "/os/" + pkgName + ".zip";
-
-      supported_fw = [
-        "12.3"
-        "12.3.1"
-        "13.5"
-      ];
-
-      partitions = [
-        {
-          name = "EFI";
-          type = "EFI";
-          size = "${toString partInfo.espSize}B";
-          format = "fat";
-          volume_id = "0x12cea600";
-          copy_firmware = true;
-          copy_installer_data = true;
-          source = "esp";
-        }
-        {
-          name = "Root";
-          type = "Linux";
-          size = "${toString partInfo.rootSize}B";
-          expand = true;
-          image = "root.img";
-        }
-      ];
-    };
+      name = "EFI";
+      type = "EFI";
+      size = "${toString partInfo.espSize}B";
+      format = "fat";
+      volume_id = "0x12cea600";
+      copy_firmware = true;
+      copy_installer_data = true;
+      source = "esp";
+    }
+    {
+      name = "Root";
+      type = "Linux";
+      size = "${toString partInfo.rootSize}B";
+      expand = true;
+      image = "root.img";
+    }
+  ];
 }

--- a/lib/make-disk-image.nix
+++ b/lib/make-disk-image.nix
@@ -184,8 +184,8 @@ let
     diskImage=$out/nixos.raw
   '';
 
-  buildImageStage1 = pkgs.vmTools.runInLinuxVM (
-    pkgs.runCommand "${name}-stage1"
+  buildImageStageOne = pkgs.vmTools.runInLinuxVM (
+    pkgs.runCommand "${name}-stage-one"
       {
         preVM = prepareStagingRoot + partitionImage;
         postVM = copyStagingRootToImage;
@@ -234,11 +234,11 @@ let
     diskImage=$out/${fileName}
   '';
 
-  buildImageStage2 = pkgs.vmTools.runInLinuxVM (
+  buildImageStageTwo = pkgs.vmTools.runInLinuxVM (
     pkgs.runCommand name
       {
         preVM = ''
-          install -m644 -t ./. ${buildImageStage1}/nixos.raw
+          install -m644 -t ./. ${buildImageStageOne}/nixos.raw
           diskImage=nixos.raw
         '';
         postVM = moveImage + makePartInfo;
@@ -317,4 +317,4 @@ let
       ''
   );
 in
-buildImageStage2
+buildImageStageTwo

--- a/modules/image-config.nix
+++ b/modules/image-config.nix
@@ -14,7 +14,7 @@
     inputs.nixos-apple-silicon.nixosModules.default
   ];
 
-  system.build."${fsType}Image" = import ../lib/make-disk-image.nix {
+  system.build.asahi-image = import ../lib/make-disk-image.nix {
     copyConfig = ./template;
     inherit
       config

--- a/modules/template/configuration.nix
+++ b/modules/template/configuration.nix
@@ -1,8 +1,4 @@
-{
-  inputs,
-  pkgs,
-  ...
-}:
+{ inputs, pkgs, ... }:
 {
   imports = [
     inputs.nixos-apple-silicon.nixosModules.default

--- a/scripts/create-release/default.nix
+++ b/scripts/create-release/default.nix
@@ -8,23 +8,27 @@
 with lib;
 let
   thisVer = removeSuffix "-dirty" version;
-  majorInt = toInt (versions.major thisVer);
-  majorMinor = versions.majorMinor thisVer;
-  minorInt = toInt (versions.minor thisVer);
-  patchInt = toInt (versions.patch thisVer);
+
+  major = toInt (versions.major thisVer);
+  minor = toInt (versions.minor thisVer);
+  patch = toInt (versions.patch thisVer);
 
   nextVer =
-    if (patchInt != 9) then
-      majorMinor + "." + (toString (patchInt + 1))
-    else if (minorInt != 9) then
+    if (patch != 9) then
       (concatStringsSep "." [
-        (toString majorInt)
-        (toString (minorInt + 1))
+        (toString major)
+        (toString minor)
+        (toString (patch + 1))
+      ])
+    else if (minor != 9) then
+      (concatStringsSep "." [
+        (toString major)
+        (toString (minor + 1))
         "0"
       ])
     else
       (concatStringsSep "." [
-        (toString (majorInt + 1))
+        (toString (major + 1))
         "0"
         "0"
       ]);

--- a/scripts/upload/upload.py
+++ b/scripts/upload/upload.py
@@ -11,18 +11,21 @@ from botocore.config import Config
 from tqdm import tqdm
 
 
-def append_installer_data(idata, url=None):
+def append_installer_data(file_paths: list, url=None):
     response = requests.get(url)
     os_list = (
         response.json() if response.status_code == 200 else {"os_list": []}
     )
-    with open(idata, "r") as data:
-        new_data = json.load(data)
-    try:
-        os_list["os_list"].append(new_data)
-        return os_list
-    except TypeError as e:
-        print(f"Error appending installer data: {str(e)}")
+
+    for file_path in file_paths:
+        with open(file_path, "r") as data:
+            new_data = json.load(data)
+        try:
+            os_list["os_list"].append(new_data)
+        except TypeError as e:
+            print(f"Error appending installer data: {str(e)}")
+
+    return os_list
 
 
 def upload_to_r2(file: str, content_type: str):
@@ -54,10 +57,21 @@ def upload_to_r2(file: str, content_type: str):
 
 
 if __name__ == "__main__":
-    pkg_zip = os.getenv("PKG_ZIP")
-    pkg_data = os.getenv("PKG_DATA")
+    result_dir = os.getenv("result_dir")
+    data_filepaths = [
+        str(path)
+        for path in Path(result_dir).iterdir()
+        if path.is_file() and path.name.endswith(".json")
+    ]
+    pkg_filepaths = [
+        str(path)
+        for path in Path(result_dir).iterdir()
+        if path.is_file() and path.name.endswith(".zip")
+    ]
+
+    base_url = os.getenv("BASE_URL")
     merged_data = append_installer_data(
-        pkg_data, url="https://cdn.qeden.dev/data/installer_data.json"
+        data_filepaths, url=f"{base_url}/data/installer_data.json"
     )
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -67,4 +81,6 @@ if __name__ == "__main__":
             json.dump(merged_data, file)
 
         upload_to_r2("installer_data.json", "text/plain")
+
+    for pkg_zip in pkg_filepaths:
         upload_to_r2(pkg_zip, "application/octet-stream")


### PR DESCRIPTION
This pull request introduces significant updates to the flake structure and CI pipeline. Key changes include the introduction of a metapackage build process which is now used in CI to build both `ext4` and `btrfs` package variants and refactoring in the upload scripts to accommodate both variants.

### Build and Release Pipeline Updates:
* Updated the GitHub Actions workflow to use `nix-fast-build` for building metapackages, leveraging 24 evaluation workers for improved performance. (`.github/workflows/build-and-release.yaml`, [.github/workflows/build-and-release.yamlL24-R27](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44L24-R27))
* Added a `BASE_URL` environment variable to the `.env` file and updated the release step to specify the result directory for uploads. (`.github/workflows/build-and-release.yaml`, [.github/workflows/build-and-release.yamlR44-R50](diffhunk://#diff-ad4426c4339c88e5a644696af58c8c29aa5ff4401faf486584641e1a542dff44R44-R50))

### NixOS Configuration Refactoring:
* Refactored `flake.nix` to modularize package definitions using a new `mkPackageVariants` function, simplifying the process of defining installer packages for different filesystem types. (`flake.nix`, [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L16-R40) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L101-R87)
* Introduced `lib/build-packages.nix` to encapsulate logic for building NixOS configurations and installer packages, replacing inline definitions in `flake.nix`. (`lib/build-packages.nix`, [lib/build-packages.nixR1-R51](diffhunk://#diff-454ded423b5294686c3b3ff40b58c3ba3eb742b7b124b234e3d65005c314beceR1-R51))

### Artifact Upload Enhancements:
* Replaced the `upload-to-r2.py` script with a refactored `upload.py` script, enabling batch processing of `.json` and `.zip` files from the result directory and appending installer data to an existing JSON file. (`scripts/upload/upload.py`, [[1]](diffhunk://#diff-188c9649ba342ed0f27bcbf5147610e9c516beef02900729ee931163f3230a79L14-R29) [[2]](diffhunk://#diff-188c9649ba342ed0f27bcbf5147610e9c516beef02900729ee931163f3230a79L57-R74) [[3]](diffhunk://#diff-188c9649ba342ed0f27bcbf5147610e9c516beef02900729ee931163f3230a79R84-R85)

### Miscellaneous Improvements:
* Renamed variables in `scripts/create-release/default.nix` for consistency and clarity when calculating version increments. (`scripts/create-release/default.nix`, [scripts/create-release/default.nixL11-R31](diffhunk://#diff-009abd00bddf6c4d2da9f3bf60bca0526652cb00b3ce802ac7ce8bf141e0965cL11-R31))
* Replaced `buildImageStage1` and `buildImageStage2` with more descriptive names (`buildImageStageOne` and `buildImageStageTwo`) in `lib/make-disk-image.nix`. (`lib/make-disk-image.nix`, [[1]](diffhunk://#diff-6fb3415a5fccb7958481f5612e076ea67f8096d43e9dce56b94df15745db6846L187-R188) [[2]](diffhunk://#diff-6fb3415a5fccb7958481f5612e076ea67f8096d43e9dce56b94df15745db6846L237-R241) [[3]](diffhunk://#diff-6fb3415a5fccb7958481f5612e076ea67f8096d43e9dce56b94df15745db6846L320-R320)

These changes collectively enhance the maintainability, performance, and usability of the build and release process for the project.