### PR TITLE
feat: change versioning format to CalVer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,7 @@
         {
           create-release = {
             type = "app";
-            program = lib.getExe (pkgs.callPackage ./scripts/create-release { inherit version; });
+            program = lib.getExe (pkgs.callPackage ./scripts/create-release { });
           };
 
           upload = {

--- a/lib/timestamp.nix
+++ b/lib/timestamp.nix
@@ -1,0 +1,120 @@
+{
+  lib ? import <nixpkgs/lib>, # for builtins.currentTime
+}:
+
+unixTimestamp:
+
+let
+  # Constants
+  secondsPerMinute = 60;
+  minutesPerHour = 60;
+  hoursPerDay = 24;
+  secondsPerDay = secondsPerMinute * minutesPerHour * hoursPerDay;
+
+  # Helper functions
+  isLeapYear = year: (lib.mod year 4 == 0 && lib.mod year 100 != 0) || (lib.mod year 400 == 0);
+
+  daysInMonth =
+    { year, month }:
+    if month == 2 then
+      if isLeapYear year then 29 else 28
+    else if
+      builtins.elem month [
+        4
+        6
+        9
+        11
+      ]
+    then
+      30
+    else
+      31;
+
+  # Convert timestamp to days since epoch and remainder seconds
+  daysSinceEpoch = unixTimestamp / secondsPerDay;
+
+  # Calculate year
+  calculateYear =
+    days:
+    let
+      # Helper to find the year by accumulating days
+      go =
+        { year, remainingDays }:
+        let
+          daysInCurrentYear = if isLeapYear year then 366 else 365;
+        in
+        if remainingDays < daysInCurrentYear then
+          { inherit year remainingDays; }
+        else
+          go {
+            year = year + 1;
+            remainingDays = remainingDays - daysInCurrentYear;
+          };
+    in
+    go {
+      year = 1970;
+      remainingDays = days;
+    };
+
+  getLast =
+    n: str:
+    let
+      len = builtins.stringLength str;
+      validN = if n > len then len else n;
+    in
+    builtins.substring (len - validN) validN str;
+
+  yearInfo = calculateYear (builtins.floor daysSinceEpoch);
+  year = yearInfo.year;
+  shortYear = lib.toInt (getLast 2 (toString yearInfo.year));
+  dayOfYear = yearInfo.remainingDays + 1; # +1 because zero-indexed
+
+  # Calculate month and day
+  calculateMonthAndDay =
+    { currentYear, remainingDays }:
+    let
+      go =
+        { month, days }:
+        let
+          daysInCurrentMonth = daysInMonth {
+            year = currentYear;
+            month = month;
+          };
+        in
+        if days <= daysInCurrentMonth then
+          {
+            inherit month;
+            day = days;
+          }
+        else
+          go {
+            month = month + 1;
+            days = days - daysInCurrentMonth;
+          };
+    in
+    go {
+      month = 1;
+      days = remainingDays;
+    };
+
+  dateInfo = calculateMonthAndDay {
+    currentYear = year;
+    remainingDays = dayOfYear;
+  };
+  month = dateInfo.month;
+  day = dateInfo.day;
+
+  # Format with leading zeros
+  pad = n: if n < 10 then "0${toString n}" else toString n;
+in
+{
+  unix = unixTimestamp;
+  date = "${toString year}-${pad month}-${pad day}";
+  inherit
+    year
+    shortYear
+    month
+    day
+    ;
+}
+# "${toString shortYear}.${toString month}.${toString day}"

--- a/scripts/create-release/create-release.sh
+++ b/scripts/create-release/create-release.sh
@@ -4,14 +4,14 @@
 # shellcheck disable=SC2154
 
 # Check if we're running from the root of the repository
-if [[ ! -f "flake.nix" || ! -f "version.nix" ]]; then
+if [[ $(git rev-parse --show-toplevel) != "$PWD" ]]; then
   echo "This script must be run from the root of the repository" >&2
   exit 1
 fi
 
 # Check if the version matches the semver pattern (without suffixes)
 semver_regex="^([0-9]+)\.([0-9]+)\.([0-9]+)$"
-if [[ ! "$this_version" =~ $semver_regex ]]; then
+if [[ ! "$version" =~ $semver_regex ]]; then
   echo "Version must match the semver pattern (e.g., 1.0.0, 2.3.4)" >&2
   exit 1
 fi
@@ -28,26 +28,40 @@ if [[ -n "$uncommited_changes" ]]; then
   echo -e "There are uncommited changes, exiting:\n${uncommited_changes}" >&2
   exit 1
 fi
-git pull git@github.com:quinneden/nixos-asahi-package main
+git pull "git@github.com:quinneden/nixos-asahi-package" main
 unpushed_commits=$(git log --format=oneline origin/main..main)
 if [[ "$unpushed_commits" != "" ]]; then
   echo -e "\nThere are unpushed changes, exiting:\n$unpushed_commits" >&2
   exit 1
 fi
 
-# Update the version file
-echo -e "{\n  version = \"$this_version\";\n  released = true;\n}" > version.nix
+# Update release.nix
+sed -i 's/released = false/released = true/' version.nix
 
 # Commit and tag the release
-git commit -am "release: v$this_version"
-git tag -a "v$this_version" -m "release: v$this_version"
+git commit -am "release: v$version"
+git tag -a "v$version" -m "release: v$version"
 git tag -d "latest" || true
-git tag -a "latest" -m "release: v$this_version"
+git tag -a "latest" -m "release: v$version"
 
-echo -e "{\n  version = \"$next_version\";\n  released = false;\n}" > version.nix
-git commit -am "chore(release): reset released flag"
+commit=$(git rev-parse HEAD)
+date=$(date +%Y-%m-%d)
+
+sed -i "s/$latestReleaseCommit/$commit/g" version.nix
+sed -i "s/$latestReleaseDate/$date/g" version.nix
+sed -i "s/$latestReleaseVersion/$version/g" version.nix
+sed -i "s/$latestReleaseTag/v$version/g" version.nix
+sed -i "s/released = true;/released = false;/g" version.nix
+
+# Reset release.nix
+git commit -am "chore: \`reset version.nix\`"
 
 echo "Release was prepared successfully!"
-echo "To push the release, run the following command:"
-echo
-echo "  git push origin main v$this_version && git push --force origin latest"
+read -rn1 -p "Push to remote? (Y/n): " input
+if [[ $input != 'y' ]]; then
+  echo "To push the release, run the following command:"
+  echo
+  echo "  git push origin main v$version && git push --force origin latest"
+else
+  git push origin main "v$version" && git push --force origin latest
+fi

--- a/scripts/create-release/default.nix
+++ b/scripts/create-release/default.nix
@@ -1,50 +1,28 @@
 {
   bash,
   git,
-  lib,
-  version,
+  gnused,
   writeShellApplication,
 }:
-with lib;
 let
-  thisVer = removeSuffix "-dirty" version;
-
-  major = toInt (versions.major thisVer);
-  minor = toInt (versions.minor thisVer);
-  patch = toInt (versions.patch thisVer);
-
-  nextVer =
-    if (patch != 9) then
-      (concatStringsSep "." [
-        (toString major)
-        (toString minor)
-        (toString (patch + 1))
-      ])
-    else if (minor != 9) then
-      (concatStringsSep "." [
-        (toString major)
-        (toString (minor + 1))
-        "0"
-      ])
-    else
-      (concatStringsSep "." [
-        (toString (major + 1))
-        "0"
-        "0"
-      ]);
+  inherit (import ../../version.nix) version latestRelease;
 in
 writeShellApplication {
   name = "create-release";
-  derivationArgs.version = thisVer;
+  derivationArgs = { inherit version; };
 
   runtimeInputs = [
     bash
     git
+    gnused
   ];
 
   text = ''
-    this_version="${thisVer}"; export this_version
-    next_version="${nextVer}"; export next_version
+    version="${version}"; export version
+    latestReleaseCommit="${latestRelease.commit}"; export latestReleaseCommit
+    latestReleaseDate="${latestRelease.date}"; export latestReleaseDate
+    latestReleaseVersion="${latestRelease.version}"; export latestReleaseVersion
+    latestReleaseTag="${latestRelease.tag}"; export latestReleaseTag
     bash ${./create-release.sh}
   '';
 }

--- a/version.nix
+++ b/version.nix
@@ -1,4 +1,15 @@
+let
+  timestamp = (import ./lib/timestamp.nix { }) builtins.currentTime;
+  inherit (timestamp) shortYear month day;
+in
 {
-  version = "0.1.5";
+  version = "${toString shortYear}.${toString month}.${toString day}";
   released = false;
+
+  latestRelease = {
+    commit = "b97da42f001d11db96e77201f9742a57f0ee6e6b";
+    date = "2025-05-04";
+    version = "0.1.4";
+    tag = "v0.1.4";
+  };
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the release process by refactoring the `create-release` script, updating version management, and adding a utility for timestamp handling. The changes enhance maintainability, flexibility, and automation in release workflows.

### Refactoring and improvements to the release process:

* **Refactored `create-release.sh` script**:
  - Updated checks to ensure the script runs from the repository root using `git rev-parse`.
  - Enhanced version file updates by using `sed` to modify `version.nix` fields dynamically, including commit, date, and version information.
  - Added an interactive prompt to confirm whether to push changes to the remote repository.

* **Simplified `create-release/default.nix`**:
  - Removed manual version calculations and replaced them with imports from `version.nix`.
  - Added `gnused` as a runtime dependency for streamlined file modifications.

### Version management:

* **Enhanced `version.nix`**:
  - Integrated a dynamic versioning system based on the current timestamp, using the newly introduced `timestamp.nix` utility.
  - Added a `latestRelease` attribute to track metadata about the most recent release, including commit hash, date, version, and tag.

### Utility for timestamp handling:

* **New `lib/timestamp.nix`**:
  - Added a utility to convert Unix timestamps into human-readable date components (year, month, day) and calculate leap years and days in a month. This utility supports dynamic versioning.